### PR TITLE
Explain need to rename `Logs` module in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,20 @@ Add this to your dune stanza for your executable
   (pps logs-ppx))
 ```
 
+and make sure that the `logs` library has also been added to the `libraries` field, e.g.,
+
+```lisp
+(library
+  (name foo)
+  (libraries logs))
+```
+
 Then you use it like this in OCaml:
 
 ```ocaml
+(* Convention to avoid name clashes *)
+module Log = Logs
+
 [%log debug "Hello %s!" "world"]
 (* Which genrates the following *)
 Logs.debug (fun m -> m "Hello %s!" "world")


### PR DESCRIPTION
This also suggests an addition to make explicit the need to have the `logs` library declared as a dependency.

I think this is a followup to #2 ?